### PR TITLE
Remove content_script to prevent it from loading on all website.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,11 +17,6 @@
       "128": "images/icon.png"
     }
   },
-  "content_scripts": [{
-      "js": ["material/material.min.js", "popup.js"],
-      "css": ["material/material.min.css"],
-      "matches": ["http://*/*", "https://*/*"]
-  }],
   "icons": {
     "16": "images/lenny.png",
     "32": "images/lenny.png",


### PR DESCRIPTION
Fixing bug with job score not able to load resume page correctly when the extension is enabled.

The issue was due to `material.min.js` being injected and run automatically on all website, and this can sometime interfere with the website's JavaScript. In this case, it interfere with JobScore's pdf viewer.

More info about `content_scripts`:
https://developer.chrome.com/extensions/content_scripts#declaratively
